### PR TITLE
Dev

### DIFF
--- a/comments_microservice/comments/models.py
+++ b/comments_microservice/comments/models.py
@@ -9,7 +9,8 @@ def not_negative(eventId):
 
 
 class Comment(models.Model):
-    author = models.CharField(max_length=150)
+    authorName = models.CharField(max_length=150)
+    authorID = models.IntegerField(default=0)
     text = models.CharField(max_length=128)
     answerId = models.IntegerField(default=0)
     eventId = models.IntegerField(validators=[not_negative])

--- a/comments_microservice/comments/tests.py
+++ b/comments_microservice/comments/tests.py
@@ -77,9 +77,9 @@ class ViewTestCase(TestCase):
     def test_api_event_validators(self):
         """Test the api cannot update if eventId is negative"""
         comment = Comment.objects.get()
-        change_comment = {'text': 'O comentario foi editado',
-                          'author': 'Fulano',
-                          'eventId': -1}
+        change_comment = {'text': 'Comentário',
+                          'author': 'Beltrano',
+                          'eventId': -2}
         res = self.client.put(
             reverse('comment-detail', kwargs={'pk': comment.id}),
             change_comment, format='json'

--- a/comments_microservice/comments/views.py
+++ b/comments_microservice/comments/views.py
@@ -18,9 +18,6 @@ class CommentList(generics.ListCreateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
 
-    def perform_create(self, serializer):
-        serializer.save(author=self.request.user)
-
 
 class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()


### PR DESCRIPTION
Mudança na maneira que salva o autor dos comentários
## Descrição
Agora é recebido um nome e um valor, que serão salvos nos campos authorName e authorID


## Motivação e Contexto
Facilitar maneira que é salvo as informações

## Como foi testado?
Manualmente


## Tipo de modificações
- [X] Correção de bug
- [ ] Nova _feature_